### PR TITLE
Use tox for testing/development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: python
-python:
-  - "3.6"
+
+matrix:
+  include:
+    - python: '3.5'
+      env: TOXENV=py35
+    - python: '3.6'
+      env: TOXENV=py36
+    - python: '3.6'
+      env: TOXENV=check
 
 install:
-  - pip install flake8 isort pytest pytest-cov codecov
-  - pip install --editable .
+  - pip install tox
 
 script:
-  - flake8 bottery
-  - isort bottery --recursive --check-only
-  - pytest --cov bottery
+  - tox
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: TOXENV=py36
     - python: '3.6'
       env: TOXENV=check
+    - python: '3.6'
+      env: TOXENV=docs
 
 install:
   - pip install tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,7 +12,7 @@ Development
 
 Use PEP-8 for code style and `isort <https://pypi.python.org/pypi/isort>`_ to sort your imports.
 
-Bottle uses `tox <http://tox.readthedocs.io>`_ for testing and general development.
+Bottery uses `tox <http://tox.readthedocs.io>`_ for testing and general development.
 
 After ``tox`` is installed, just execute::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,30 @@
+.. _contributing:
+
+Contributing
+============
+
+Contributions are highly welcomed and appreciated.  Every little help counts,
+so do not hesitate!
+
+Contributions can be made in the form of feature requests, bug reports and feedback.
+
+
+Development
+-----------
+
+Use PEP-8 for code style and `isort <https://pypi.python.org/pypi/isort>`_ to sort your imports.
+
+Bottle uses `tox <http://tox.readthedocs.io>`_ for testing and general development.
+
+After ``tox`` is installed, just execute::
+
+    $ tox
+
+To run all tests in all supported Python versions and lint checks.
+
+If you want to run a specific test in a specific environment, you can also execute::
+
+
+    $ tox -e py36 -- tests/test_cli.py
+
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,3 @@
-.. _contributing:
-
 Contributing
 ============
 
@@ -27,4 +25,11 @@ If you want to run a specific test in a specific environment, you can also execu
 
     $ tox -e py36 -- tests/test_cli.py
 
+
+Documentation
+-------------
+
+Documentation updates or fixes are welcome. To generate docs locally, execute::
+
+    $ tox -e docs
 

--- a/README.md
+++ b/README.md
@@ -65,19 +65,7 @@ $ bottery run --debug
 
 ## Development
 
-Tests are run using [tox](http://tox.readthedocs.io). After `tox` is installed, just execute:
-
-```
-$ tox
-```
-
-To run all tests in Python 3.5, 3.6 and lint checks.
-
-If you want to run a specific test in an specific environment, you can do:
-
-```
-$ tox -e py36 -- tests/test_cli.py
-```
+Please see [our contribution guide](CONTRIBUTING.rst).
 
 
 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ PLATFORMS = {
 ```bash
 $ bottery run --debug
 ```
+
+## Development
+
+Tests are run using [tox](http://tox.readthedocs.io). After `tox` is installed, just execute:
+
+```
+$ tox
+```
+
+To run all tests in Python 3.5, 3.6 and lint checks.
+
+If you want to run a specific test in an specific environment, you can do:
+
+```
+$ tox -e py36 -- tests/test_cli.py
+```
+
+
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,3 @@
+.. _contributing:
+
+.. include:: ../CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,3 +20,4 @@ This part of the documentation, which is mostly prose, begins with some backgrou
    :maxdepth: 2
 
    installation
+   contributing

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py35,py36,check
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    codecov
+commands =
+    pytest --cov {envsitepackagesdir}/bottery {posargs:tests}
+
+[testenv:check]
+deps =
+    flake8
+    isort
+commands =
+    flake8 bottery
+    isort bottery --recursive --check-only

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,5 @@ usedevelop = True
 changedir = docs
 deps =
     sphinx
-    PyYAML
 commands =
     sphinx-build -W -b html . _build

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,13 @@ deps =
 commands =
     flake8 bottery
     isort bottery --recursive --check-only
+
+[testenv:docs]
+skipsdist = True
+usedevelop = True
+changedir = docs
+deps =
+    sphinx
+    PyYAML
+commands =
+    sphinx-build -W -b html . _build


### PR DESCRIPTION
Tox is the de-facto standard tool for testing in Python today. It automatically:

1. Creates a source dist of the package;
2. Creates a new virtual environment for each Python version you want to support;
3. Runs the tests using the code installed on the package. This is important to catch packaging mistakes like forgetting to include a data file or python package inside your source dist.

By using tox you reduce the entry barrier for developers to contribute. Users which know `tox` know that they just have to type `tox` at the root of your project to be able to contribute.

Basically every serious project in Python today uses `tox` for testing automation. Just a few examples: [pip](https://github.com/pypa/pip), [pipfile](https://github.com/pypa/pipfile), [virtualenv](https://github.com/pypa/virtualenv), [requests](https://github.com/requests/requests), etc. Is actually hard to find a project which doesn't use `tox` I think. 😁 

Well this is just a suggestion. I understand perfectly if you guys don't want to add this right now and want to reject the PR, no problem. 👍 