### PR TITLE
Fix key error at telegram build_message

### DIFF
--- a/bottery/platform/__init__.py
+++ b/bottery/platform/__init__.py
@@ -52,10 +52,16 @@ class BasePlataform:
             data = await request.json()
             logger.debug('[%s] Building message', self.platform)
             message = self.build_message(data)
-            view = discover_view(message)
-            if not view:
-                logger.warn('[%s] Pattern not found for message from %s',
-                            message.platform, message.user)
+
+            if message:
+                view = discover_view(message)
+                if not view:
+                    logger.warn('[%s] Pattern not found for message from %s',
+                                message.platform, message.user)
+                    return web.Response()
+            else:
+                logger.warn('Not a message data received, only message data'
+                            ' is supported at the moment')
                 return web.Response()
 
             logger.info('[%s] Message from %s', self.platform, message.user)

--- a/bottery/platform/telegram.py
+++ b/bottery/platform/telegram.py
@@ -83,14 +83,19 @@ class TelegramEngine(platform.BasePlataform):
         Telegram API.
         https://core.telegram.org/bots/api#update
         '''
-        return Message(
-            id=data['message']['message_id'],
-            platform=self.platform,
-            text=data['message']['text'],
-            user=TelegramUser(data['message']['from']),
-            timestamp=data['message']['date'],
-            raw=data,
-        )
+        message_data = data.get('message')
+
+        if message_data:
+            return Message(
+                id=message_data['message_id'],
+                platform=self.platform,
+                text=message_data['text'],
+                user=TelegramUser(message_data['from']),
+                timestamp=message_data['date'],
+                raw=data,
+            )
+        else:
+            return None
 
     def handler_response(self, response):
         data = {

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,8 +1,9 @@
 from unittest import mock
 
 import pytest
-
-from bottery.platform.telegram import TelegramAPI, TelegramUser, mixed_case
+from bottery.message import Message
+from bottery.platform.telegram import (TelegramAPI, TelegramEngine,
+                                       TelegramUser, mixed_case)
 
 
 # TelegramUser
@@ -61,3 +62,50 @@ def test_telegram_api_request(mocked_requests):
     api.send_message(data=data)
 
     mocked_requests.post.assert_called_once_with(url, json=data)
+
+
+# Telegram Engine
+
+def test_build_message():
+    engine = TelegramEngine(token='')
+    data = {
+        'update_id': 123456,
+        'message': {
+            'message_id': 1,
+            'from': {
+                'id': 321,
+                'is_bot': False,
+                'first_name': 'Andrew',
+                'last_name': 'Martin',
+                'username': 'amartin',
+                'language_code': 'en-US'
+            },
+            'chat': {
+                'id': 42,
+                'first_name': 'Andrew',
+                'last_name': 'Martin',
+                'username': 'amartin',
+                'type': 'private'
+            },
+            'date': 1506805222,
+            'text': 'ping'
+        }
+    }
+
+    message = engine.build_message(data)
+
+    assert type(message) == Message
+    assert message.text == 'ping'
+
+
+def test_build_message_with_non_message_data():
+    engine = TelegramEngine(token='')
+    data = {
+        'update_id': 123456,
+        'message_updated': {
+        }
+    }
+
+    message = engine.build_message(data)
+
+    assert message is None


### PR DESCRIPTION
In order to solve that i created a skip case returning `None` at `build_message`.
Then treated the `None` case at the handler by skipping the view lookup and warning the user at `--debug` that non message data isn't currently supported.
And added some test