### PR TITLE
Fix 'git clone' section

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,7 +60,7 @@ You can either clone the public repository:
 
 .. code-block:: bash
 
-    $ git clone http://github.com/rougeth/bottery.git
+    $ git clone https://github.com/rougeth/bottery.git
 
 Or, download the tarball:
 


### PR DESCRIPTION
It was using http protocol instead of https