### PR TITLE
Add testing for ColoredFormatter

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
-import logging
+import logging, logging.config
 import os
 
 import click
 from click.testing import CliRunner
+from testfixtures import LogCapture
 
 from bottery.cli import cli, debug_option
+from bottery.log import ColoredFormatter,DEFAULT_LOGGING
 
 
 def test_debug_flag_enabled():
@@ -48,3 +50,24 @@ def test_startproject():
         assert result.exit_code == 0
         assert os.listdir() == [project_name]
         assert os.listdir(project_name) == project_files
+
+		
+def test_ColoredFormatter():
+    c = ColoredFormatter()
+    expected = ['DEBUG',
+                '\x1b[34mINFO\x1b[0m',
+                '\x1b[33mWARN\x1b[0m',
+                '\x1b[31mERROR\x1b[0m',
+                '\x1b[30m\x1b[41mCRITICAL\x1b[0m'
+               ]
+    logging.config.dictConfig(DEFAULT_LOGGING)
+    with LogCapture(names='bottery') as l:
+        logger = logging.getLogger('bottery')
+        logger.debug('DEBUG')
+        logger.info('INFO')
+        logger.warning('WARN')
+        logger.error('ERROR')
+        logger.critical('CRITICAL')
+        records = [x for x in l.records]
+        for i in range(len(records)):
+            assert c.format(records[i]) == expected[i]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-import logging, logging.config
+import logging
+import logging.config
 import os
 
 import click
@@ -6,7 +7,7 @@ from click.testing import CliRunner
 from testfixtures import LogCapture
 
 from bottery.cli import cli, debug_option
-from bottery.log import ColoredFormatter,DEFAULT_LOGGING
+from bottery.log import ColoredFormatter, DEFAULT_LOGGING
 
 
 def test_debug_flag_enabled():
@@ -51,15 +52,16 @@ def test_startproject():
         assert os.listdir() == [project_name]
         assert os.listdir(project_name) == project_files
 
-		
+
 def test_ColoredFormatter():
     c = ColoredFormatter()
-    expected = ['DEBUG',
-                '\x1b[34mINFO\x1b[0m',
-                '\x1b[33mWARN\x1b[0m',
-                '\x1b[31mERROR\x1b[0m',
-                '\x1b[30m\x1b[41mCRITICAL\x1b[0m'
-               ]
+    expected = [
+        'DEBUG',
+        '\x1b[34mINFO\x1b[0m',
+        '\x1b[33mWARN\x1b[0m',
+        '\x1b[31mERROR\x1b[0m',
+        '\x1b[30m\x1b[41mCRITICAL\x1b[0m'
+    ]
     logging.config.dictConfig(DEFAULT_LOGGING)
     with LogCapture(names='bottery') as l:
         logger = logging.getLogger('bottery')

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     pytest
     pytest-cov
     codecov
-	testfixtures
+    testfixtures
 commands =
     pytest --cov {envsitepackagesdir}/bottery {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     pytest-cov
     codecov
+	testfixtures
 commands =
     pytest --cov {envsitepackagesdir}/bottery {posargs:tests}
 


### PR DESCRIPTION
Checks ANSI escape codes for correct coloring based on the DEFAULT_COLORS variable using the LogCapture class from testfixtures and the ColoredFormatter subclass.  100% coverage on log.py.

#44 
#48 