### PR TITLE
Removing documentation from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![PyPI](https://img.shields.io/pypi/v/bottery.svg)](https://pypi.python.org/pypi/bottery)
 
 * [Usage](#usage)
+  * [Documentation](http://docs.bottery.io)
   * [Installing](#installing)
   * [Creating a project](#creating-a-project)
-  * [Configuring Telegram](#configuring-telegram)
   * [Running](#running)
 * [Development](#development)
 
@@ -24,53 +24,6 @@ $ pip install bottery
 $ bottery startproject librarybot
 ```
 
-This will create a librarybot directory in your current directory with three files inside:
-
-```bash
-librarybot/
-    __init__.py
-    patterns.py
-    settings.py
-```
-
-- The outer **librarybot/** root directory is just a container for your project. Its name doesn’t matter to Bottery; you can rename it to anything you like.
-- **librarybot/\_\_init\_\_.py**: An empty file that tells Python that this directory should be considered a Python package. If you’re a Python beginner, read more about packages in the official Python docs;
-- **librarybot/patterns.py**: The Pattern declarations for this Bottery project;
-- **library/settings.py**: Settings/configuration for this Bottery project.
-
-### Configuring Telegram
-We can get new messages from two different ways: defining a webhook with SSL implemented on Telegram or through polling. For now, Bottery implements the first way and because of that you need to define a valid and accessible externally hostname on settings.py:
-
-```python
-# settings.py
-HOSTNAME = 'mybot.example.com'
-```
-
-If you're developing or testing your bot, you can use a tunnel to expose Bottery. Services like [ngrok](https://ngrok.com/) helps a lot to do that.
-
-Bottery register the telegram webhook url (that uses the `HOSTNAME` variable on settings) and Telegram uses that url send the new messages that your bot receives.
-
-The Bottery setup with ngrok is simple. Once it is [installed](https://ngrok.com/download), run `$ ngrok http 8000` (if you need help running ngrok, check [its documentation](https://ngrok.com/docs). This command will give you two urls (`http` and `https`) of the created tunnel. Get the hostname (full url without `https://` part) and fill `HOSTNAME` on `settings.py`.
-
-Now, you just need to get your bot token the fill on `settings.py`:
-
-```python
-# settings.py
-PLATFORMS = {
-    'telegram': {
-        'ENGINE': 'bottery.platform.telegram',
-        'OPTIONS': {
-            'token': 'your-token-here',
-        }
-    },
-}
-```
-
-`ENGINE`: For now, only Telegram is available.
-
-`token`: A token provided by [@BotFather](https://t.me/BotFather). Do not share it!
-
-
 ### Running
 ```bash
 $ bottery run --debug
@@ -79,7 +32,3 @@ $ bottery run --debug
 ## Development
 
 Please see [our contribution guide](CONTRIBUTING.rst).
-
-
-
-


### PR DESCRIPTION
The docs on the README were not updated since now we are developing the website version. 

Removed the main configuration definition and left only the install, starproject and run. 

Added link to documentation.