### PR TITLE
Add banner with python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/rougeth/bottery.svg?branch=master)](https://travis-ci.org/rougeth/bottery)
 [![Build status](https://ci.appveyor.com/api/projects/status/we3h64nj98vvxcre/branch/master?svg=true)](https://ci.appveyor.com/project/rougeth/bottery/branch/master)
 [![PyPI](https://img.shields.io/pypi/v/bottery.svg)](https://pypi.python.org/pypi/bottery)
+[![Versions](https://img.shields.io/pypi/pyversions/bottery.svg)](https://pypi.python.org/pypi/bottery)
 
 * [Usage](#usage)
   * [Documentation](http://docs.bottery.io)


### PR DESCRIPTION
This helps users identify which Python versions are supported at a glance (you can see how it looks like [on my fork](https://github.com/nicoddemus/bottery/tree/pyversions)).