### PR TITLE
[WIP] Fixed typo in tox environment check (and subsequent uncaught errors)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ deps =
     flake8
     isort
 commands =
-    flake8 bottery test
-    isort bottery test --recursive --check-only
+    flake8 bottery tests
+    isort bottery tests --recursive --check-only
 
 [testenv:docs]
 skipsdist = True


### PR DESCRIPTION
Both flake8 and isort were looking for a `test` folder, instead of `tests`. Although flake8 runs correctly, isort caught a couple issues.