### PR TITLE
CLI based interface through simple dict configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 /site
 
 # End of https://www.gitignore.io/api/python
+
+settings\.py

--- a/app.py
+++ b/app.py
@@ -1,0 +1,5 @@
+from bottery.app import App
+
+
+app = App()
+app.run()

--- a/bottery/conf/patterns.py
+++ b/bottery/conf/patterns.py
@@ -1,4 +1,9 @@
+'''Classes that do the comparison of the User words
+ and a predefined pattern'''
+
+
 class Pattern:
+    '''Basic equal comparison'''
     def __init__(self, pattern, view):
         self.pattern = pattern
         self.view = view
@@ -10,13 +15,15 @@ class Pattern:
 
 
 class DefaultPattern:
+    '''Check always True'''
     def __init__(self, view):
         self.view = view
 
-    def check(self, message):
+    def check(self, message=None):
         # regarless the message, this pattern should return
         # the view, so, there is no checks to be made here
         return self.view
+
 
 class FuncPattern(Pattern):
     '''Receives a function to preprocess the incoming message
@@ -33,18 +40,19 @@ class FuncPattern(Pattern):
             return self.view
         return False
 
+
 class HookableFuncPattern(Pattern):
     '''Receives a function to preprocess the incoming message
     text before comparing it to the pattern.
     Allows use of regular expressions, selecting partial words for
     routing, etc
-    pre_process: a function to process message on check action before comparing
-    with pattern
+    pre_process: a function to process message on check action before
+     comparing with pattern
     context: string with history of messages
-    conversation: HookPattern Object that will hook any next messages to this pattern
-        (see ConversationPattern)'''
-    def __init__(self, pattern, view, pre_process, \
-                 hook_pattern=None, save_context=True, \
+    conversation: HookPattern Object that will hook any next messages
+     to this pattern (see ConversationPattern)'''
+    def __init__(self, pattern, view, pre_process,
+                 hook_pattern=None, save_context=True,
                  rules=None, params=None):
         self.pre_process = pre_process
         self.context = []
@@ -73,7 +81,7 @@ class HookableFuncPattern(Pattern):
 
     def check(self, message):
         '''Simple check'''
-        if (not self.conversation is None) and self.conversation.has_hook():
+        if (self.conversation is not None) and self.conversation.has_hook():
             return True
         text, _ = self.pre_process(message.text)
         if text == self.pattern:
@@ -86,7 +94,7 @@ class HookableFuncPattern(Pattern):
         First we see if the context has to be set, then we run the view.
         While view returns True, the hook will remain'''
         # If hooked, go directly to view
-        if (not self.conversation is None) and self.conversation.has_hook():
+        if (self.conversation is not None) and self.conversation.has_hook():
             if self.save_context:
                 self.context.append(message.text)
                 message.text = " ".join(self.context)
@@ -103,7 +111,8 @@ class HookableFuncPattern(Pattern):
                 try:
                     self.context = []
                     self.context.append(text)
-                    if (not self.conversation is None) and (not self.conversation.has_hook()):
+                    if (self.conversation is not None) and \
+                       (not self.conversation.has_hook()):
                         self.conversation.begin_hook(self)
                 except Exception as err:
                     print(err)
@@ -117,8 +126,8 @@ class HookPattern(Pattern):
     _pattern: a Hookable Pattern Object
     end_hook_words: a list of words that terminates the Hook
     Usage:
-    Put as first pattern
-    On a view, call set_conversation(Pattern) to ensure the next message will go to this Pattern
+    Put as first pattern. On a view, call set_conversation(Pattern)
+     to ensure the next message will go to this Pattern
     Also on a view, call end_conversation to release the hook'''
     def __init__(self, end_hook_words=None):
         self._pattern = None
@@ -129,8 +138,8 @@ class HookPattern(Pattern):
         '''Pass the calling away'''
         if self._pattern is None:
             return False
-        
-        if not self._end_hook_words is None:
+
+        if self._end_hook_words is not None:
             for word in message.text.split(' '):
                 if word in self._end_hook_words:
                     self.end_hook()

--- a/bottery/conf/patterns.py
+++ b/bottery/conf/patterns.py
@@ -17,3 +17,143 @@ class DefaultPattern:
         # regarless the message, this pattern should return
         # the view, so, there is no checks to be made here
         return self.view
+
+class FuncPattern(Pattern):
+    '''Receives a function to preprocess the incoming message
+    text before comparing it to the pattern.
+    Allows use of regular expressions, selecting partial words for
+    routing, etc'''
+    def __init__(self, pattern, view, pre_process):
+        self.pre_process = pre_process
+        Pattern.__init__(self, pattern, view)
+
+    def check(self, message):
+        text, _ = self.pre_process(message.text)
+        if text == self.pattern:
+            return self.view
+        return False
+
+class HookableFuncPattern(Pattern):
+    '''Receives a function to preprocess the incoming message
+    text before comparing it to the pattern.
+    Allows use of regular expressions, selecting partial words for
+    routing, etc
+    pre_process: a function to process message on check action before comparing
+    with pattern
+    context: string with history of messages
+    conversation: HookPattern Object that will hook any next messages to this pattern
+        (see ConversationPattern)'''
+    def __init__(self, pattern, view, pre_process, \
+                 hook_pattern=None, save_context=True, \
+                 rules=None, params=None):
+        self.pre_process = pre_process
+        self.context = []
+        self.conversation = hook_pattern
+        self.save_context = save_context
+        self.rules = rules
+        self.params = params
+        Pattern.__init__(self, pattern, view)
+
+    def safe_call_view(self, message):
+        '''Local function to check return of view.
+        Just to treat errors if view returns only response'''
+        from inspect import signature
+        sig = signature(self.view)
+        if str(sig).find('rules') == -1:
+            tuple_return = self.view(message)
+        else:
+            tuple_return = self.view(message, self.rules, self.params)
+        if type(tuple_return) is tuple:
+            response = tuple_return[0]
+            hook = tuple_return[1]
+        else:
+            response = tuple_return
+            hook = False
+        return response, hook
+
+    def check(self, message):
+        '''Simple check'''
+        if (not self.conversation is None) and self.conversation.has_hook():
+            return True
+        text, _ = self.pre_process(message.text)
+        if text == self.pattern:
+            return True
+        return False
+
+    def call_view(self, message):
+        ''' If a view wants to begin a conversation, it needs to return True
+        Default is False.
+        First we see if the context has to be set, then we run the view.
+        While view returns True, the hook will remain'''
+        # If hooked, go directly to view
+        if (not self.conversation is None) and self.conversation.has_hook():
+            print("After first pass")
+            if self.save_context:
+                self.context.append(message.text)
+                message.text = " ".join(self.context)
+            response, hook = self.safe_call_view(message)    
+            if not hook:
+                self.conversation.end_hook()
+                self.context = []
+            return response
+        # Else, begin normal check
+        text, _ = self.pre_process(message.text)
+        if text == self.pattern:
+            response, hook = self.safe_call_view(message)    
+            if hook:
+                try:
+                    self.context = []
+                    self.context.append(text)
+                    if (not self.conversation is None) and (not self.conversation.has_hook()):
+                        self.conversation.begin_hook(self)
+                except Exception as err:
+                    print(err)
+            return response
+        return False
+ 
+
+class HookPattern(Pattern):
+    '''FirstPattern to be checked. Allows a Pattern to "capture" and release
+    the flow if it receives an incomplete messsage
+    _pattern: a Hookable Pattern Object
+    end_hook_words: a list of words that terminates the Hook
+    Usage:
+    Put as first pattern
+    On a view, call set_conversation(Pattern) to ensure the next message will go to this Pattern
+    Also on a view, call end_conversation to release the hook'''
+    def __init__(self, end_hook_words=None):
+        self._pattern = None
+        self._end_hook_words = end_hook_words
+        Pattern.__init__(self, "", None)
+
+    def check(self, message):
+        '''Pass the calling away'''
+        if self._pattern is None:
+            return False
+        
+        if not self._end_hook_words is None:
+            for word in message.text.split(' '):
+                if word in self._end_hook_words:
+                    self.end_hook()
+                    return False
+        # print('Passing the calling!!!')
+        return self._pattern.check(message)
+
+    def begin_hook(self, apattern):
+        '''Pass the pattern that will begin a conversation'''
+        self._pattern = apattern
+
+    def end_hook(self):
+        '''Releases pointer to Pattern ending a conversation'''
+        self._pattern = None
+
+    def has_hook(self):
+        '''Return if hook is active'''
+        return not (self._pattern is None)
+
+    def call_view(self, message):
+        '''pass the calling away'''
+        if self._pattern is None:
+            return "Error: no pattern hooked"
+        return self._pattern.call_view(message)
+

--- a/bottery/conf/patterns.py
+++ b/bottery/conf/patterns.py
@@ -63,7 +63,7 @@ class HookableFuncPattern(Pattern):
             tuple_return = self.view(message)
         else:
             tuple_return = self.view(message, self.rules, self.params)
-        if type(tuple_return) is tuple:
+        if isinstance(tuple_return, tuple):
             response = tuple_return[0]
             hook = tuple_return[1]
         else:
@@ -87,11 +87,10 @@ class HookableFuncPattern(Pattern):
         While view returns True, the hook will remain'''
         # If hooked, go directly to view
         if (not self.conversation is None) and self.conversation.has_hook():
-            print("After first pass")
             if self.save_context:
                 self.context.append(message.text)
                 message.text = " ".join(self.context)
-            response, hook = self.safe_call_view(message)    
+            response, hook = self.safe_call_view(message)
             if not hook:
                 self.conversation.end_hook()
                 self.context = []
@@ -99,7 +98,7 @@ class HookableFuncPattern(Pattern):
         # Else, begin normal check
         text, _ = self.pre_process(message.text)
         if text == self.pattern:
-            response, hook = self.safe_call_view(message)    
+            response, hook = self.safe_call_view(message)
             if hook:
                 try:
                     self.context = []
@@ -110,7 +109,7 @@ class HookableFuncPattern(Pattern):
                     print(err)
             return response
         return False
- 
+
 
 class HookPattern(Pattern):
     '''FirstPattern to be checked. Allows a Pattern to "capture" and release
@@ -156,4 +155,3 @@ class HookPattern(Pattern):
         if self._pattern is None:
             return "Error: no pattern hooked"
         return self._pattern.call_view(message)
-

--- a/bottery/platform/__init__.py
+++ b/bottery/platform/__init__.py
@@ -8,6 +8,31 @@ from bottery.exceptions import ImproperlyConfigured
 
 logger = logging.getLogger('bottery.platforms')
 
+def discover_and_run_view(message):
+    if message is None:
+        return None
+    base = os.getcwd()
+    patterns_path = os.path.join(base, 'patterns.py')
+    if not os.path.isfile(patterns_path):
+        raise ImproperlyConfigured('Could not find patterns module')
+
+    patterns = importlib.import_module('patterns').patterns
+    for pattern in patterns:
+        if pattern.check(message):
+            logger.debug('[%s] Pattern found', message.platform)
+            print('Pattern found:', pattern)
+            call_view = getattr(pattern, "call_view", None)
+            if callable(call_view):
+                response = pattern.call_view(message)
+                return response
+            if isinstance(pattern.view, str):
+                view = importlib.import_module(pattern.view)
+            else:
+                view = pattern.view
+            return view(message)
+
+    # raise Exception('No Pattern found!')
+    return None
 
 def discover_view(message):
     base = os.getcwd()

--- a/bottery/platform/__init__.py
+++ b/bottery/platform/__init__.py
@@ -8,6 +8,7 @@ from bottery.exceptions import ImproperlyConfigured
 
 logger = logging.getLogger('bottery.platforms')
 
+
 def discover_and_run_view(message):
     if message is None:
         return None
@@ -33,6 +34,7 @@ def discover_and_run_view(message):
 
     # raise Exception('No Pattern found!')
     return None
+
 
 def discover_view(message):
     base = os.getcwd()

--- a/bottery/platform/telegram.py
+++ b/bottery/platform/telegram.py
@@ -5,7 +5,7 @@ import requests
 
 from bottery import platform
 from bottery.message import Message
-from bottery.platform import discover_view, discover_and_run_view
+from bottery.platform import discover_and_run_view
 from bottery.user import User
 
 logger = logging.getLogger('bottery.telegram')

--- a/bottery/platform/telegram.py
+++ b/bottery/platform/telegram.py
@@ -5,7 +5,7 @@ import requests
 
 from bottery import platform
 from bottery.message import Message
-from bottery.platform import discover_view
+from bottery.platform import discover_view, discover_and_run_view
 from bottery.user import User
 
 logger = logging.getLogger('bottery.telegram')
@@ -135,11 +135,9 @@ class TelegramEngine(platform.BasePlatform):
         message = self.build_message(data)
 
         # Try to find a view (best name?) to response the message
-        view = discover_view(message)
-        if not view:
+        response = discover_and_run_view(message)
+        if not response:
             return
-
-        response = view(message)
 
         # TODO: Choose between Markdown and HTML
         data = {

--- a/bottery/views.py
+++ b/bottery/views.py
@@ -1,2 +1,111 @@
+import sys
+import json
+import urllib.request
+
+
 def pong(message):
     return 'pong'
+
+def locate_next(words, rules, level=1):
+    '''Recursively process the rule chain
+    Used by view access_api_rules'''
+    try:
+        lista = words.split(' ')
+        next_level = {}
+        url = ""
+        for key, value in rules.items():
+            if key == lista[0]:
+                # print('key found =', lista[0])
+                if isinstance(value, dict):
+                    for k, v in value.items():
+                        next_level[k] = v
+                else:
+                    url = value
+
+        if url:
+            return url, level
+        else:
+            if len(lista) > 1:
+                return locate_next(' '.join(lista[1:]), next_level, level+1)
+            return next_level, level
+    except AttributeError:
+        print("Atribute error. Possibly misconfiguration of rules:", sys.exc_info()[0])
+        raise
+    except:
+        print("Unexpected error:", sys.exc_info()[0])
+        raise
+
+def process_parameters(name, level, params):
+    '''Process the parameter chain
+    Used by view access_api_rules'''
+    key = name.strip() + ':' + str(level)
+    param_list = params.get(key, None)
+    if param_list is None:
+        return None
+    result = []
+    n_required = 0
+    for param in param_list:
+        result.append(param['name'])
+        if param['required'] == True:
+            n_required+=1
+            
+    return result, n_required    
+
+def access_api_rules(message, rules, params_dict=None):
+    '''Acess a JSON 'REST' API maped by rules
+    text: a phrase, a sequence of words by space passed by the Pattern object
+    rules: a dict on format rules = {'command1': {'subcommand1': 'url1',
+                                                 {'subcommand2': 'url2'} },
+                                     'command2': 'url3'
+                                    }
+    params_dict: a dict/list on format
+    params = {'command:level': [{'name': 'name1', 'required': True},
+                                {'name': 'name2', 'required': False}
+                               ],
+              'command2:level': [{'name': 'name2.1', 'required': True}]
+             }
+    '''
+    text = message.text
+    alist = text.split(' ')
+    url, level = locate_next(text, rules)
+    if isinstance(url, dict):
+        if url == {}:
+            return 'Unrecognized command, exiting...', False
+        message = url.pop('_message', '')
+        return message + ' - '.join([key for key in url]), True
+    str_params = ''
+    if params_dict is None:
+        str_params = '%20'.join(alist[level:])
+        if not str_params:
+            return 'Enter parameters: ', True
+    else:
+        n_params_passed = len(alist) - level
+        params_list, n_required = process_parameters(alist[level-1], level,params_dict)
+        if n_params_passed < n_required:
+            return 'Required parameters: ' + str(n_required) + \
+                   ' Order: ' + ' '.join(params_list) + \
+                   ' Number of parameters passed: ' + str(n_params_passed), True
+        # else n_params_passed >= n_required
+        str_params = '?'
+        cont = 0
+        for param in alist[level:]:
+            str_params =  str_params + params_list[cont] + '=' + \
+                          param + '&'
+            cont += 1
+        str_params = str_params[:-1] # Take off last '&'
+        
+    url = url + str_params
+    response_text = urllib.request.urlopen(url).read()
+    resposta = response_text.decode('utf-8')
+    json_resposta = json.loads(resposta)
+    str_resposta = ""
+    print(json_resposta)
+    if isinstance(json_resposta, list):
+        for linha in json_resposta:
+            for key, value in linha.items():
+                str_resposta = str_resposta + key + ': ' + str(value) + ' \n '
+    else:
+        for key, value in json_resposta.items():
+            str_resposta = str_resposta + key + ': ' + str(value) + ' \n '
+        
+    return str_resposta, False

--- a/bottery/views.py
+++ b/bottery/views.py
@@ -1,6 +1,6 @@
 import json
-import sys
 import shlex
+import sys
 from urllib.request import urlopen
 
 

--- a/bottery/views.py
+++ b/bottery/views.py
@@ -7,11 +7,13 @@ from urllib.request import urlopen
 def pong(message):
     return 'pong'
 
+
 def locate_next(words, rules, level=1):
     '''Recursively process the rule chain
     Used by view access_api_rules'''
     try:
-        # alist = words.split(' ') (like in shell, preserves expressions in quotes)
+        # alist = words.split(' ')
+        # (like in shell, preserves expressions in quotes)
         alist = shlex.split(words)
         next_level = {}
         url = ""
@@ -28,14 +30,17 @@ def locate_next(words, rules, level=1):
             return url, level
         else:
             if len(alist) > 1:
-                return locate_next(' '.join(alist[1:]), next_level, level+1)
+                return locate_next(' '.join(alist[1:]),
+                                   next_level, level+1)
             return next_level, level
     except AttributeError:
-        print("Atribute error. Possibly misconfiguration of rules:", sys.exc_info()[0])
+        print("Atribute error. Possibly misconfiguration of rules:",
+              sys.exc_info()[0])
         raise
     except:
         print("Unexpected error:", sys.exc_info()[0])
         raise
+
 
 def process_parameters(name, level, params):
     '''Process the parameter chain
@@ -53,6 +58,7 @@ def process_parameters(name, level, params):
 
     return result, n_required
 
+
 def access_api_rules(message, rules, params_dict=None):
     '''Acess a JSON 'REST' API maped by rules
     text: a phrase, a sequence of words by space passed by the Pattern object
@@ -68,7 +74,8 @@ def access_api_rules(message, rules, params_dict=None):
              }
     '''
     text = message.text
-    # Splits like in shell: splits/tokenizes on spaces, preserving expressions between quotes
+    # Splits like in shell: splits/tokenizes on spaces,
+    # preserving expressions between quotes
     alist = shlex.split(text)
     url, level = locate_next(text, rules)
     if isinstance(url, dict):
@@ -83,11 +90,13 @@ def access_api_rules(message, rules, params_dict=None):
             return 'Enter parameters: ', True
     else:
         n_params_passed = len(alist) - level
-        params_list, n_required = process_parameters(alist[level-1], level,params_dict)
+        params_list, n_required = process_parameters(alist[level-1],
+                                                     level, params_dict)
         if n_params_passed < n_required:
             return 'Required parameters: ' + str(n_required) + \
                    ' Order: ' + ' '.join(params_list) + \
-                   ' Number of parameters passed: ' + str(n_params_passed), True
+                   ' Number of parameters passed: ' + \
+                   str(n_params_passed), True
         # else n_params_passed >= n_required
         str_params = '?'
         cont = 0
@@ -95,7 +104,7 @@ def access_api_rules(message, rules, params_dict=None):
             str_params = str_params + params_list[cont] + '=' + \
                          param + '&'
             cont += 1
-        str_params = str_params[:-1] # Take off last '&'
+        str_params = str_params[:-1]  # Take off last '&'
 
     url = url + str_params
     response_text = urlopen(url).read()

--- a/patterns.py
+++ b/patterns.py
@@ -1,13 +1,15 @@
 '''Configuration of the routes, or vocabulary of the bot'''
 from bottery.conf.patterns import Pattern, DefaultPattern, \
-    HookableFuncPattern, HookPattern, FuncPattern
+    HookableFuncPattern, HookPattern
 from bottery.views import pong, access_api_rules
 from views import help_text, say_help, END_HOOK_LIST, two_tokens
 
 
 rules = {'tec': {'rank': 'http://brasilico.pythonanywhere.com/_rank?words=',
-                 'filtra': 'http://brasilico.pythonanywhere.com/_filter_documents?afilter=',
-                 'capitulo': 'http://brasilico.pythonanywhere.com/_document_content/',
+                 'filtra':
+                  'http://brasilico.pythonanywhere.com/_filter_documents?afilter=',
+                 'capitulo':
+                  'http://brasilico.pythonanywhere.com/_document_content/',
                  '_message': 'Informe o comando: '
                 }
         }

--- a/patterns.py
+++ b/patterns.py
@@ -1,0 +1,31 @@
+'''Configuration of the routes, or vocabulary of the bot'''
+from bottery.conf.patterns import Pattern, DefaultPattern, \
+    HookableFuncPattern, HookPattern, FuncPattern
+from bottery.views import pong, access_api_rules
+from views import help_text, say_help, END_HOOK_LIST, two_tokens
+
+
+rules = {'tec': {'rank': 'http://brasilico.pythonanywhere.com/_rank?words=',
+                 'filtra': 'http://brasilico.pythonanywhere.com/_filter_documents?afilter=',
+                 'capitulo': 'http://brasilico.pythonanywhere.com/_document_content/',
+                 '_message': 'Informe o comando: '
+                }
+        }
+
+ 
+rules_cep = {'cep': {'busca': 'http://api.postmon.com.br/v1/cep/',
+                     '_message': 'Informe o comando: '
+                }
+        }
+
+
+conversation = HookPattern(END_HOOK_LIST)
+patterns = [
+    conversation,
+    Pattern('ping', pong),
+    Pattern('help', help_text),
+    HookableFuncPattern('tec', access_api_rules, two_tokens, conversation, rules=rules),
+    HookableFuncPattern('cep', access_api_rules, two_tokens, conversation, rules=rules_cep),
+    DefaultPattern(say_help)
+]
+ 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -49,6 +49,7 @@ def test_default_pattern_check_message():
     result = pattern.check(message)
     assert result == view
 
+
 def test_hook_pattern_no_hook():
     '''Check basic fields and False return if no hook
     active'''
@@ -61,7 +62,7 @@ def test_hook_pattern_no_hook():
 
 def test_hook_pattern_check_right_message():
     '''
-    Check if Hook forwards to Pattern class 
+    Check if Hook forwards to Pattern class
     return the view when message checks with
     pattern.
     '''
@@ -83,13 +84,18 @@ def test_hook_pattern_check_right_message():
 
 
 def test_hookable_func_pattern_instance():
-    def view(): return 'Hello world'
-    def pre_process(): return 'ping'
+
+    def view():
+        return 'Hello world'
+
+    def pre_process():
+        return 'ping'
+
     hook_pattern = HookPattern()
     rules = {}
     params = {}
     pattern = HookableFuncPattern('ping', view, pre_process,
-        hook_pattern, rules=rules, params=params)
+                                  hook_pattern, rules=rules, params=params)
     assert pattern.pattern == 'ping'
     assert pattern.view == view
     assert pattern.pre_process == pre_process
@@ -99,57 +105,81 @@ def test_hookable_func_pattern_instance():
     assert pattern.rules == rules
     assert pattern.params == params
 
+
 def test_hookable_func_pattern_right_message():
-    def view(): return 'Hello world'
-    def pre_process(text): return text, 'params'
+
+    def view():
+        return 'Hello world'
+
+    def pre_process(text):
+        return text, 'params'
+
     hook_pattern = HookPattern()
     rules = {}
     params = {}
     pattern = HookableFuncPattern('ping', view, pre_process,
-        hook_pattern, rules=rules, params=params)
+                                  hook_pattern, rules=rules, params=params)
     message = type('Message', (object,), {'text': 'ping'})
     assert pattern.check(message) is True
 
+
 def test_hookable_func_pattern_wrong_message_and_hook():
-    def view(): return 'Hello world'
-    def pre_process(text): return text, 'params'
+
+    def view():
+        return 'Hello world'
+
+    def pre_process(text):
+        return text, 'params'
+
     hook_pattern = HookPattern()
     rules = {}
     params = {}
     pattern = HookableFuncPattern('ping', view, pre_process,
-        hook_pattern, rules=rules, params=params)
+                                  hook_pattern, rules=rules, params=params)
     message = type('Message', (object,), {'text': 'wrong'})
     assert pattern.check(message) is False
     # Now, activate Hook and test again
     hook_pattern.begin_hook(pattern)
     assert pattern.check(message) is True
 
+
 def test_hookable_func_pattern_safe_call_view():
-    def view(message): return message.text
-    def pre_process(text): return text, 'params'
+
+    def view(message):
+        return message.text
+
+    def pre_process(text):
+        return text, 'params'
+
     hook_pattern = HookPattern()
     rules = {}
     params = {}
     pattern = HookableFuncPattern('ping', view, pre_process,
-        hook_pattern, rules=rules, params=params)
+                                  hook_pattern, rules=rules, params=params)
     message = type('Message', (object,), {'text': 'one_value'})
     text, hook = pattern.safe_call_view(message)
     assert text == message.text
     assert hook is False
 
+
 def test_hookable_func_pattern_call_view():
+    '''HookableFuncPattern.callview Test'''
+
+    def view(message):
+        return view_result_list[ind]
+
+    def pre_process(text):
+        return text, 'params'
+
     view_result_list = [('one', True),
                         ('two', True),
                         ('end', False)]
     ind = 0
-    def view(message): 
-        return view_result_list[ind]
-    def pre_process(text): return text, 'params'
     hook_pattern = HookPattern()
     rules = {}
     params = {}
     pattern = HookableFuncPattern('ping', view, pre_process,
-        hook_pattern, rules=rules, params=params)
+                                  hook_pattern, rules=rules, params=params)
     right_message = type('Message', (object,), {'text': 'ping'})
     wrong_message = type('Message', (object,), {'text': 'wrong'})
     assert pattern.check(wrong_message) is False
@@ -170,4 +200,3 @@ def test_hookable_func_pattern_call_view():
     text = pattern.call_view(wrong_message)
     assert text == view_result_list[ind][0]
     assert hook_pattern.check(right_message) is False
-

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,5 +1,5 @@
-from bottery.conf.patterns import DefaultPattern, Pattern, \
-    HookableFuncPattern, HookPattern
+from bottery.conf.patterns import (DefaultPattern, HookableFuncPattern,
+                                   HookPattern, Pattern)
 
 
 def test_pattern_instance():

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,4 +1,5 @@
-from bottery.conf.patterns import DefaultPattern, Pattern
+from bottery.conf.patterns import DefaultPattern, Pattern, \
+    HookableFuncPattern, HookPattern
 
 
 def test_pattern_instance():
@@ -47,3 +48,126 @@ def test_default_pattern_check_message():
     message = type('Message', (object,), {'text': 'ping'})
     result = pattern.check(message)
     assert result == view
+
+def test_hook_pattern_no_hook():
+    '''Check basic fields and False return if no hook
+    active'''
+    pattern = HookPattern('end')
+    assert pattern._pattern is None
+    assert pattern._end_hook_words == 'end'
+    assert pattern.check(None) is False
+    assert pattern.has_hook() is False
+
+
+def test_hook_pattern_check_right_message():
+    '''
+    Check if Hook forwards to Pattern class 
+    return the view when message checks with
+    pattern.
+    '''
+    '''
+    Check if DefaultPattern class return the message if any pattern
+    is given.
+    '''
+    def view(): return 'Hello world'
+    pattern = DefaultPattern(view)
+    message = type('Message', (object,), {'text': 'ping'})
+    hook_pattern = HookPattern('end')
+    hook_pattern.begin_hook(pattern)
+    assert hook_pattern.has_hook() is True
+    result = hook_pattern.check(message)
+    assert result == view
+    hook_pattern.end_hook()
+    assert hook_pattern.has_hook() is False
+    assert hook_pattern.check(message) is False
+
+
+def test_hookable_func_pattern_instance():
+    def view(): return 'Hello world'
+    def pre_process(): return 'ping'
+    hook_pattern = HookPattern()
+    rules = {}
+    params = {}
+    pattern = HookableFuncPattern('ping', view, pre_process,
+        hook_pattern, rules=rules, params=params)
+    assert pattern.pattern == 'ping'
+    assert pattern.view == view
+    assert pattern.pre_process == pre_process
+    assert pattern.context == []
+    assert pattern.conversation == hook_pattern
+    assert pattern.save_context is True
+    assert pattern.rules == rules
+    assert pattern.params == params
+
+def test_hookable_func_pattern_right_message():
+    def view(): return 'Hello world'
+    def pre_process(text): return text, 'params'
+    hook_pattern = HookPattern()
+    rules = {}
+    params = {}
+    pattern = HookableFuncPattern('ping', view, pre_process,
+        hook_pattern, rules=rules, params=params)
+    message = type('Message', (object,), {'text': 'ping'})
+    assert pattern.check(message) is True
+
+def test_hookable_func_pattern_wrong_message_and_hook():
+    def view(): return 'Hello world'
+    def pre_process(text): return text, 'params'
+    hook_pattern = HookPattern()
+    rules = {}
+    params = {}
+    pattern = HookableFuncPattern('ping', view, pre_process,
+        hook_pattern, rules=rules, params=params)
+    message = type('Message', (object,), {'text': 'wrong'})
+    assert pattern.check(message) is False
+    # Now, activate Hook and test again
+    hook_pattern.begin_hook(pattern)
+    assert pattern.check(message) is True
+
+def test_hookable_func_pattern_safe_call_view():
+    def view(message): return message.text
+    def pre_process(text): return text, 'params'
+    hook_pattern = HookPattern()
+    rules = {}
+    params = {}
+    pattern = HookableFuncPattern('ping', view, pre_process,
+        hook_pattern, rules=rules, params=params)
+    message = type('Message', (object,), {'text': 'one_value'})
+    text, hook = pattern.safe_call_view(message)
+    assert text == message.text
+    assert hook is False
+
+def test_hookable_func_pattern_call_view():
+    view_result_list = [('one', True),
+                        ('two', True),
+                        ('end', False)]
+    ind = 0
+    def view(message): 
+        return view_result_list[ind]
+    def pre_process(text): return text, 'params'
+    hook_pattern = HookPattern()
+    rules = {}
+    params = {}
+    pattern = HookableFuncPattern('ping', view, pre_process,
+        hook_pattern, rules=rules, params=params)
+    right_message = type('Message', (object,), {'text': 'ping'})
+    wrong_message = type('Message', (object,), {'text': 'wrong'})
+    assert pattern.check(wrong_message) is False
+    assert pattern.check(right_message) is True
+    # Call view that returns true must begin a Hook
+    text = pattern.call_view(right_message)
+    assert text == view_result_list[ind][0]
+    assert hook_pattern.check(wrong_message) is True
+    assert hook_pattern.check(right_message) is True
+    # Repeating call must mantain the Hook
+    ind = 1
+    text = pattern.call_view(wrong_message)
+    assert text == view_result_list[ind][0]
+    assert hook_pattern.check(wrong_message) is True
+    assert hook_pattern.check(right_message) is True
+    # Last call (that returns false) must end the Hook
+    ind = 2
+    text = pattern.call_view(wrong_message)
+    assert text == view_result_list[ind][0]
+    assert hook_pattern.check(right_message) is False
+

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,33 @@
-from bottery.views import pong
+from bottery.views import pong, locate_next, \
+    process_parameters, access_api_rules
 
 
 def test_pong():
     assert pong('any_string') == 'pong'
     assert pong(1) == 'pong'
     assert pong(None) == 'pong'
+
+
+rules = {'book': {'list': '/list',
+                 'show': '/show/',
+                 'filter': '/filter',
+                 '_message': 'Enter command: '
+                }
+        }
+params = {'filter:2': [{'name': 'author', 'required': True},
+                       {'name': 'name', 'required': True},
+                       {'name': 'publisher', 'required': False}
+                      ]
+         }
+
+def test_locate_next():
+    assert locate_next('book', rules) == (rules['book'], 1)
+    assert locate_next('book list', rules) == ('/list', 2)
+    assert locate_next('book not_exist_com', rules) == ({}, 2)
+
+def test_process_parameters():
+    assert process_parameters('filter', 2, params) == (['author', 'name', 'publisher'], 2)
+
+def test_access_api_rules():
+    pass
+    

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,20 @@
+'''Unit Tests for the views inside bottery.views'''
 from unittest import mock
 from bottery.views import pong, locate_next, \
     process_parameters, access_api_rules
+
+RULES = {'book':
+         {'list': '/list',
+          'view': '/view/',
+          'filter': '/filter',
+          '_message': 'Enter command: '
+          }
+         }
+PARAMS = {'filter:2':
+          [{'name': 'author', 'required': True},
+           {'name': 'name', 'required': True},
+              {'name': 'publisher', 'required': False}
+           ]}
 
 
 def test_pong():
@@ -9,35 +23,28 @@ def test_pong():
     assert pong(None) == 'pong'
 
 
-rules = {'book': {'list': '/list',
-                  'view': '/view/',
-                  'filter': '/filter',
-                  '_message': 'Enter command: '
-                 }
-        }
-params = {'filter:2': [{'name': 'author', 'required': True},
-                       {'name': 'name', 'required': True},
-                       {'name': 'publisher', 'required': False}
-                      ]
-         }
-
 def test_locate_next():
-    assert locate_next('book', rules) == (rules['book'], 1)
-    assert locate_next('book list', rules) == ('/list', 2)
-    assert locate_next('book not_exist_com', rules) == ({}, 2)
+    # Test examples configuration
+    assert locate_next('book', RULES) == (RULES['book'], 1)
+    assert locate_next('book list', RULES) == ('/list', 2)
+    assert locate_next('book not_exist_com', RULES) == ({}, 2)
+
 
 def test_process_parameters():
-    assert process_parameters('filter', 2, params) == (['author', 'name', 'publisher'], 2)
+    # Test examples configuration
+    assert process_parameters('filter', 2, PARAMS) == \
+        (['author', 'name', 'publisher'], 2)
+
 
 @mock.patch('bottery.views.urlopen')
 def test_call_api(urlopen):
+    # Test examples configuration
     urlopen.return_value.read.return_value = '{"mocked": "mocked"}'
     message = type('Message', (object,), {'text': 'book'})
-    resp, hook = access_api_rules(message, rules)
+    resp, hook = access_api_rules(message, RULES)
     assert hook is True
     assert resp.find('Enter command:') == 0
     message.text = 'book view'
-    assert access_api_rules(message, rules) == ('Enter parameters: ', True)
-    message.text = 'book view corcunda'
-    assert access_api_rules(message, rules) == ('mocked: mocked \n ', False)
-
+    assert access_api_rules(message, RULES) == ('Enter parameters: ', True)
+    message.text = 'book view 1'
+    assert access_api_rules(message, RULES) == ('mocked: mocked \n ', False)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,8 @@
 '''Unit Tests for the views inside bottery.views'''
 from unittest import mock
-from bottery.views import pong, locate_next, \
-    process_parameters, access_api_rules
+
+from bottery.views import (access_api_rules, locate_next, pong,
+                           process_parameters)
 
 RULES = {'book':
          {'list': '/list',

--- a/views.py
+++ b/views.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+'''Views customizadas utilizadas neste projeto
+São as funcões que geram o conteúdo para a submissão à
+API que o Usuário acessa.
+'''
+import json
+import urllib.request
+
+
+ULRAPP = 'http://brasilico.pythonanywhere.com/'
+STATUS = ['OK', 'Divergente', 'Sem Lacre']
+END_HOOK_LIST = ['fim', 'end', 'exit', 'sair']
+
+def two_tokens(text):
+    '''Receives a text string, splits on first space, return
+    first word of list/original sentence and the rest of the sentence
+    '''
+    lista = text.split(' ')
+    return lista[0], " ".join(lista[1:])
+
+def help_text(message):
+    '''Retorna a lista de Patterns/ disponíveis'''
+    # TODO Fazer modo automatizado
+    lstatus = [str(key) + ': ' + value + ' ' for key, value in list(enumerate(STATUS))]
+    str_end_hook = ', '.join(END_HOOK_LIST)
+    return  ('help - esta tela de ajuda \n'
+             'ping - teste, retorna "pong"\n'
+            'tec - entra na aplicação TEC \n' + \
+            'cep - entra na aplicação CEP \n' + \
+            str_end_hook + ' - Sai de uma aplicação \n')
+
+
+def say_help(message):
+    '''Se comando não reconhecido'''
+    return 'Não entendi o pedido. \n Digite help para uma lista de comandos.'


### PR DESCRIPTION
#76 
A collection of classes and Patterns that allow to use bottery to do a "rule based" user interface in the command line way, mapping "commands"(sequence of words) to "actions" (http urls for JSON APIs) and parsing parameters also. All with basic unit tests, and an example of implementation on the '/patterns.py' file.

Reads the configuration from a simple dict and makes all the context and flow management.

It is a initial idea, but I have already easily implemented access to a Telegram bot to 3 diferent JSON APIs with it.

Although fancy chatbots do "Natural Language Processing", to do real actions, in the end of the NLP flow we will always have a Softmax classificator that will map "I wanna shop", "I want stuf", "Browse your clothes", and whatever to "catalog list", for example. So im most chatbots the "NLP layer" probably will be on top of a "rule based" layer. I think this could be very useful if improved a litle. In fact, for me, it is already useful.

Needed litle changes on plataform/ that havent breaked back compatibility.

Improvements needed:
1. An async http request. (Since asyncio needs a chain of async method calls, this improvement needs to be made in the core)  Problem already reported in #77 

2. The view probably would be better as an object than a function, with an interface defined so the developer can personalize the parsing of the response (like doing json_to_md or some manual parsing), overriding a "parse_response" method.