### PR TITLE
Improve test_platform a bit by using parametrization

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -3,29 +3,18 @@ import pytest
 from bottery.platform import BaseEngine
 
 
-def test_baseengine_platform():
-    """Check if platform attr raise NotImplementedError"""
+@pytest.mark.parametrize('attr', ['platform', 'tasks'])
+def test_baseengine_attrs(attr):
+    """Check if attributes from the public API raise NotImplementedError"""
     engine = BaseEngine()
     with pytest.raises(NotImplementedError):
-        engine.platform
+        getattr(engine, attr)
 
 
-def test_baseengine_tasks():
-    """Check if tasks attr raise NotImplementedError"""
+@pytest.mark.parametrize('method_name', ['build_message', 'configure'])
+def test_baseengine_calls(method_name):
+    """Check if method calls from public API raise NotImplementedError"""
     engine = BaseEngine()
     with pytest.raises(NotImplementedError):
-        engine.tasks
-
-
-def test_baseengine_build_message():
-    """Check if build_message method raise NotImplementedError"""
-    engine = BaseEngine()
-    with pytest.raises(NotImplementedError):
-        engine.build_message()
-
-
-def test_baseengine_configure():
-    """Check if configure method raise NotImplementedError"""
-    engine = BaseEngine()
-    with pytest.raises(NotImplementedError):
-        engine.configure()
+        method = getattr(engine, method_name)
+        method()


### PR DESCRIPTION
Following up the comment by @rougeth [here](https://github.com/rougeth/bottery/pull/90#issuecomment-336649191), sorry about the delay!

The tests are fine, but you can use pytest's [parametrization](https://docs.pytest.org/en/latest/parametrize.html) to avoid some duplication, and this really shines when more methods/attributes are added because you just have add a new name to one of the lists.

Here's the output in my computer:

```
============================= test session starts =============================
platform win32 -- Python 3.6.0, pytest-3.2.2, py-1.4.34, pluggy-0.4.0 -- x:\bottery\.env36\scripts\python.exe
cachedir: .cache
rootdir: X:\bottery, inifile:
plugins: testdox-1.0.1, mock-1.6.3, cov-2.5.1
collected 4 items

tests/test_platform.py::test_baseengine_attrs[platform] PASSED
tests/test_platform.py::test_baseengine_attrs[tasks] PASSED
tests/test_platform.py::test_baseengine_calls[build_message] PASSED
tests/test_platform.py::test_baseengine_calls[configure] PASSED

========================== 4 passed in 0.01 seconds ===========================
```