### PR TITLE
Modify responsability of calling view

### DIFF
--- a/bottery/platform/__init__.py
+++ b/bottery/platform/__init__.py
@@ -9,6 +9,33 @@ from bottery.exceptions import ImproperlyConfigured
 logger = logging.getLogger('bottery.platforms')
 
 
+def discover_and_run_view(message):
+    if message is None:
+        return None
+    base = os.getcwd()
+    patterns_path = os.path.join(base, 'patterns.py')
+    if not os.path.isfile(patterns_path):
+        raise ImproperlyConfigured('Could not find patterns module')
+
+    patterns = importlib.import_module('patterns').patterns
+    for pattern in patterns:
+        if pattern.check(message):
+            logger.debug('[%s] Pattern found', message.platform)
+            print('Pattern found:', pattern)
+            call_view = getattr(pattern, "call_view", None)
+            if callable(call_view):
+                response = pattern.call_view(message)
+                return response
+            if isinstance(pattern.view, str):
+                view = importlib.import_module(pattern.view)
+            else:
+                view = pattern.view
+            return view(message)
+
+    # raise Exception('No Pattern found!')
+    return None
+
+
 def discover_view(message):
     base = os.getcwd()
     patterns_path = os.path.join(base, 'patterns.py')

--- a/bottery/platform/telegram.py
+++ b/bottery/platform/telegram.py
@@ -5,7 +5,7 @@ import requests
 
 from bottery import platform
 from bottery.message import Message
-from bottery.platform import discover_view
+from bottery.platform import discover_and_run_view
 from bottery.user import User
 
 logger = logging.getLogger('bottery.telegram')
@@ -50,6 +50,7 @@ class TelegramUser(User):
     Telegram User reference
     https://core.telegram.org/bots/api#user
     '''
+
     def __init__(self, sender):
         self.id = sender['id']
         self.first_name = sender['first_name']
@@ -135,11 +136,9 @@ class TelegramEngine(platform.BasePlatform):
         message = self.build_message(data)
 
         # Try to find a view (best name?) to response the message
-        view = discover_view(message)
-        if not view:
+        response = discover_and_run_view(message)
+        if not response:
             return
-
-        response = view(message)
 
         # TODO: Choose between Markdown and HTML
         data = {


### PR DESCRIPTION
A small modification. In actual code, discover_view just passes the view to telegramAPI, then telegramAPI passes the messsage to the view. To ensure comomn behavior to future APIs, the base plataform can take more responsability, so TelegramAPI can pass the message to BasePlataform, that will call the view, not just discover. The APIs can still treat / process the message before passing to the function.

Also, when calling the view, the new function also checks if the active pattern has a function to call views (seeing if a method called "call_view" exists). If it exists,  passes the responsability to call view to Pattern. 

This flow will allow the Patterns that implement the call_view method - and now have access to the return of the view - to make decisions about the flow allowing more complex and flexible interactions.
