### PR TITLE
Allow engine to run multiple tasks

### DIFF
--- a/bottery/app.py
+++ b/bottery/app.py
@@ -50,7 +50,7 @@ class App:
             tasks = engine.tasks
 
             if len(tasks):
-                self.tasks.append(*tasks)
+                self.tasks.extend(tasks)
 
             logger.debug('[%s] Ready', engine.platform)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -66,7 +66,7 @@ def test_app_configure_without_platforms(mocked_settings):
 
 
 def test_app_configure_with_tasks(mocked_engine):
-    """App should have empty tasks if not defined  on engine"""
+    """App should have empty tasks if not defined on engine"""
 
     mocked_engine['instance'].tasks = []
     app = App()
@@ -76,7 +76,7 @@ def test_app_configure_with_tasks(mocked_engine):
 
 
 def test_app_configure_with_multiple_tasks(mocked_engine):
-    """App should have multiple tasks if defined  on engine"""
+    """App should have multiple tasks if defined on engine"""
     async def fake_task(session):
         await asyncio.sleep(0)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -76,7 +76,7 @@ def test_app_configure_with_tasks(mocked_engine):
 
 
 def test_app_configure_with_multiple_tasks(mocked_engine):
-    """App should have empty tasks if not defined  on engine"""
+    """App should have multiple tasks if defined  on engine"""
     async def fake_task(session):
         await asyncio.sleep(0)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,11 +68,26 @@ def test_app_configure_without_platforms(mocked_settings):
 def test_app_configure_with_tasks(mocked_engine):
     """App should have empty tasks if not defined  on engine"""
 
-    mocked_engine['instance'].tasks.return_value = []
+    mocked_engine['instance'].tasks = []
     app = App()
     app.configure_platforms()
 
     assert not app.tasks
+
+
+def test_app_configure_with_multiple_tasks(mocked_engine):
+    """App should have empty tasks if not defined  on engine"""
+    async def fake_task(session):
+        await asyncio.sleep(0)
+
+    first_task = fake_task
+    second_task = fake_task
+
+    mocked_engine['instance'].tasks = [first_task, second_task]
+    app = App()
+    app.configure_platforms()
+
+    assert app.tasks == [first_task, second_task]
 
 
 def test_app_configure_with_platforms(mocked_engine):


### PR DESCRIPTION
I noticed what I think was a small bug when I was looking at the recursion limit issue. By the way, thanks for showing me how to use trampoline functions to escape tail call recursion issue, that blew my mind.

`append` only accepts a single argument, I think the patch keeps the semantics intact.