### PR TITLE
Updated `DefaultPattern` example documentation

### DIFF
--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -49,7 +49,7 @@ after it will be ignored.
 
 .. code-block:: py
    
-    from bottery.patterns import DefaultPattern
+    from bottery.conf.patterns import DefaultPattern
 
     def not_found(message):
         return "Sorry, I can't understand what you're saying :("


### PR DESCRIPTION
[The example shown in documentation section about DefaultPattern](http://docs.bottery.io/en/latest/patterns.html#default-pattern) is importing from `bottery.patterns` instead of `bottery.conf.patterns`.