### PR TITLE
Add KeyInterrupt handle to app.run

### DIFF
--- a/bottery/app.py
+++ b/bottery/app.py
@@ -63,3 +63,10 @@ class App:
         logger.debug('Tasks created')
 
         self.loop.run_forever()
+
+    def stop(self):
+        self.session.close()
+        # Exit event loop at the next suitable opportunity...
+        self.loop.stop()
+        # ...and now close it.
+        self.loop.close()

--- a/bottery/cli.py
+++ b/bottery/cli.py
@@ -54,4 +54,8 @@ def startproject(name):
 @debug_option
 def run(port, debug):
     app = App()
-    app.run()
+
+    try:
+        app.run()
+    except KeyboardInterrupt:
+        app.stop()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -110,7 +110,16 @@ def test_app_run(mocked_asyncio):
 
     app = App()
     app.run()
+
     mocked_event_loop = mocked_asyncio.get_event_loop.return_value
 
     mocked_asyncio.get_event_loop.assert_called_with()
     mocked_event_loop.run_forever.assert_called_with()
+
+
+def test_app_stop():
+    app = App()
+    app.stop()
+
+    assert app.loop.is_closed()
+    assert app.session.closed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,17 @@ def test_app_run_is_called(mocked_run):
     assert mocked_run.called
 
 
+@mock.patch('bottery.cli.App.run')
+@mock.patch('bottery.cli.App.stop')
+def test_keyboard_interrupt_correctly_close_app(mocked_stop, mocked_run):
+    runner = CliRunner()
+    mocked_run.side_effect = KeyboardInterrupt()
+    runner.invoke(run)
+
+    assert mocked_run.called
+    assert mocked_stop.called
+
+
 def test_debug_flag_enabled():
     logger = logging.getLogger('bottery')
     logger.setLevel(logging.INFO)


### PR DESCRIPTION
### Issue
fix #88 

### What I do
I create a `.stop` method to `App` and call it on `cli.py` when `app.run()` handle a `KeyInterrupt` exception