### PR TITLE
Add attrs as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     },
     install_requires=[
         'aiohttp',
+        'attrs',
         'click',
         'halo',
         'jinja2',


### PR DESCRIPTION
An error is raised because the module `attrs` was not in requirements