### PR TITLE
Send reply to group/channel

### DIFF
--- a/bottery/message.py
+++ b/bottery/message.py
@@ -10,6 +10,7 @@ class Message:
     id = attr.ib()
     platform = attr.ib()
     user = attr.ib()
+    chat = attr.ib()
     text = attr.ib()
     timestamp = attr.ib()
     raw = attr.ib()

--- a/bottery/platform/messenger/engine.py
+++ b/bottery/platform/messenger/engine.py
@@ -62,6 +62,7 @@ class MessengerEngine(BaseEngine):
             user=data['sender']['id'],
             timestamp=data['timestamp'],
             raw=data,
+            chat=None,  # TODO: Refactor build_messages and Message class
         )
 
     async def message_handler(self, data):

--- a/bottery/platform/telegram/engine.py
+++ b/bottery/platform/telegram/engine.py
@@ -139,7 +139,8 @@ class TelegramEngine(platform.BaseEngine):
 
     def get_chat_id(self, message):
         '''
-        Telegram chat type can be either "private", "group", "supergroup" or "channel".
+        Telegram chat type can be either "private", "group", "supergroup" or
+        "channel".
         Return user ID if it is of type "private", chat ID otherwise.
         '''
         if message.chat.type == 'private':
@@ -161,5 +162,5 @@ class TelegramEngine(platform.BaseEngine):
 
         # TODO: Choose between Markdown and HTML
         # TODO: Verify response status
-        await self.api.send_message(chat_id=self.get_chat_id(message), text=response,
-                                    parser_mode='markdown')
+        await self.api.send_message(chat_id=self.get_chat_id(message),
+                                    text=response, parser_mode='markdown')

--- a/bottery/platform/telegram/engine.py
+++ b/bottery/platform/telegram/engine.py
@@ -31,6 +31,7 @@ class TelegramUser:
 
         return s.format(u=self)
 
+
 class TelegramChat:
     '''
     Telegram Chat reference

--- a/bottery/platform/telegram/engine.py
+++ b/bottery/platform/telegram/engine.py
@@ -137,6 +137,16 @@ class TelegramEngine(platform.BaseEngine):
             raw=data,
         )
 
+    def get_chat_id(self, message):
+        '''
+        Telegram chat type can be either "private", "group", "supergroup" or "channel".
+        Return user ID if it is of type "private", chat ID otherwise.
+        '''
+        if message.chat.type == 'private':
+            return message.user.id
+
+        return message.chat.id
+
     async def message_handler(self, data):
         message = self.build_message(data)
         print('[%s] Message from %s' % (self.engine_name, message.user))
@@ -149,10 +159,7 @@ class TelegramEngine(platform.BaseEngine):
         # TODO: Test if the view returned something or not
         response = await self.get_response(view, message)
 
-        chat_id = message.user.id
-        if not message.chat.type == 'private':
-            chat_id = message.chat.id
         # TODO: Choose between Markdown and HTML
         # TODO: Verify response status
-        await self.api.send_message(chat_id=chat_id, text=response,
+        await self.api.send_message(chat_id=self.get_chat_id(message), text=response,
                                     parser_mode='markdown')

--- a/bottery/platform/telegram/engine.py
+++ b/bottery/platform/telegram/engine.py
@@ -31,6 +31,26 @@ class TelegramUser:
 
         return s.format(u=self)
 
+class TelegramChat:
+    '''
+    Telegram Chat reference
+    https://core.telegram.org/bots/api#chat
+    '''
+    def __init__(self, chat):
+        self.id = chat['id']
+        self.type = chat['type']
+        self.title = chat.get('title')
+        self.username = chat.get('username')
+
+    def __str__(self):
+        s = '{u.id}'
+        if self.title:
+            s += ' {u.title}'
+        if self.username:
+            s += ' {u.username}'
+
+        return s.format(u=self)
+
 
 class TelegramEngine(platform.BaseEngine):
     platform = 'telegram'
@@ -111,6 +131,7 @@ class TelegramEngine(platform.BaseEngine):
             platform=self.platform,
             text=message_data['text'],
             user=TelegramUser(message_data['from']),
+            chat=TelegramChat(message_data['chat']),
             timestamp=message_data['date'],
             raw=data,
         )
@@ -127,7 +148,10 @@ class TelegramEngine(platform.BaseEngine):
         # TODO: Test if the view returned something or not
         response = await self.get_response(view, message)
 
+        chat_id = message.user.id
+        if not message.chat.type == 'private':
+            chat_id = message.chat.id
         # TODO: Choose between Markdown and HTML
         # TODO: Verify response status
-        await self.api.send_message(chat_id=message.user.id, text=response,
+        await self.api.send_message(chat_id=chat_id, text=response,
                                     parser_mode='markdown')

--- a/tests/test_platform_telegram.py
+++ b/tests/test_platform_telegram.py
@@ -1,0 +1,18 @@
+import aiohttp
+
+import pytest
+
+from bottery.platform.telegram.api import TelegramAPI
+
+
+def test_platform_telegram_api_non_existent_method():
+    api = TelegramAPI('token', aiohttp.ClientSession)
+    with pytest.raises(AttributeError):
+        api.non_existent_method()
+
+
+@pytest.mark.asyncio
+async def test_platform_telegram_api_get_updates():
+    api = TelegramAPI('token', aiohttp.ClientSession)
+    with pytest.raises(TypeError):
+        await api.get_updates()

--- a/tests/test_platform_telegram.py
+++ b/tests/test_platform_telegram.py
@@ -1,5 +1,4 @@
 import aiohttp
-
 import pytest
 
 from bottery.platform.telegram.api import TelegramAPI

--- a/tests/test_platform_telegram.py
+++ b/tests/test_platform_telegram.py
@@ -1,9 +1,8 @@
 import pytest
 
 from bottery.message import Message
-from bottery.platform.telegram.engine import TelegramChat
-from bottery.platform.telegram.engine import TelegramEngine
-from bottery.platform.telegram.engine import TelegramUser
+from bottery.platform.telegram.engine import (TelegramChat, TelegramEngine,
+                                              TelegramUser)
 
 
 @pytest.fixture

--- a/tests/test_platform_telegram.py
+++ b/tests/test_platform_telegram.py
@@ -2,6 +2,7 @@ import aiohttp
 import pytest
 
 from bottery.platform.telegram.api import TelegramAPI
+from bottery.platform.telegram.engine import TelegramEngine
 
 
 def test_platform_telegram_api_non_existent_method():
@@ -15,3 +16,20 @@ async def test_platform_telegram_api_get_updates():
     api = TelegramAPI('token', aiohttp.ClientSession)
     with pytest.raises(TypeError):
         await api.get_updates()
+
+
+def test_platform_telegram_engine_get_chat_id_private():
+    user = type('TelegramUser', (), {'id': '123'})
+    chat = type('TelegramChat', (), {'type': 'private'})
+    message = type('Message', (), {'user': user, 'chat': chat})
+    engine = TelegramEngine
+
+    assert engine.get_chat_id(engine, message) == '123'
+
+
+def test_platform_telegram_engine_get_chat_id_group():
+    chat = type('TelegramChat', (), {'id': '456', 'type': 'group'})
+    message = type('Message', (), {'chat': chat})
+    engine = TelegramEngine
+
+    assert engine.get_chat_id(engine, message) == '456'


### PR DESCRIPTION
Currently, bot always sends replies to the user by PM regardless of the origin of the message (PM or group). This enables bot to send replies to group.