### PR TITLE
Enable view to not respond a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 _Changes to be released_
 
+#### Bug fixes
+
+- Stop responding with `null` when a view doesn't return anything ([#154](https://github.com/rougeth/bottery/issues/154))
+
 
 ## Bottery 0.1.1 (2018-04-28)
 

--- a/bottery/platform/__init__.py
+++ b/bottery/platform/__init__.py
@@ -53,10 +53,22 @@ class BaseEngine:
         else:
             response = view(message)
 
+        return self.prepare_response(response, message)
+
+    def prepare_response(self, response, message):
         if isinstance(response, Response):
             return response
 
-        return Response(source=message, text=response)
+        if isinstance(response, str):
+            return Response(source=message, text=response)
+
+        if response is not None:
+            logger.error(
+                '[%s] View should only return str or Response',
+                self.engine_name,
+            )
+
+        return None
 
     async def prepare_get_response(self):
         get_response = self._get_response

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -1,6 +1,11 @@
 Views
 =====
 
+A view function is simply a Python function that takes a message, process it and
+returns or not a response. If the view returns a `str` or a **Response**
+object, Bottery will use the returned object as a response. If it doesn't
+returns anything, Bottery will consider that message doesn't need response.
+
 
 Working with templates
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -9,8 +14,8 @@ Sometimes you need complex and big messages to be returned by your patterns.
 Bottery is able to render and respond messages using templates written in
 markdown.
 
-On your project directory, create a folder named "**templates**". Your templates should be
-kept inside this folder so Bottery can find them. For other configuration,
+On your project directory, create a folder named "**templates**". Your templates
+should be kept inside this folder so Bottery can find them. For other configuration,
 please check the `settings`  section.
 
 Let's create a template called `hello.md`:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from bottery.message import Response
 from bottery.platform import BaseEngine
 from utils import AsyncMock
 
@@ -55,6 +56,32 @@ async def test_get_response_from_views(view, settings):
     engine.discovery_view = mock.Mock(return_value=view)
     response = await engine.get_response('ping')
     assert response.text == 'pong'
+
+
+def test_prepare_response():
+    engine = BaseEngine()
+    response = engine.prepare_response('response', 'message')
+    assert isinstance(response, Response)
+    assert response.source == 'message'
+    assert response.text == 'response'
+
+
+def test_prepare_response_with_response_obj():
+    expected_response = Response(source='message', text='response')
+    engine = BaseEngine()
+    response = engine.prepare_response(expected_response, 'message')
+    assert response == expected_response
+
+
+@mock.patch('bottery.platform.logger.error')
+def test_prepare_response_none(mocked_error):
+    """
+    If response is not a str or a Response, it should returns None
+    """
+
+    engine = BaseEngine()
+    assert engine.prepare_response(0, 'message') is None
+    assert mocked_error.call_count == 1
 
 
 def test_baseengine_handling_message():


### PR DESCRIPTION
After this pull request, we are going to be able to write views that doesn't return a message. This is the expected behavior, if the view doesn't return a message, the user doesn't get a response.

Closes: https://github.com/rougeth/bottery/issues/154
