### PR TITLE
Improve GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,12 @@
-Hi! Thank you for contributing to **Bottery**!
+Hi! Thank you for contributing to Bottery!
 
 If you are submiting a...
 
-- **bug report**, the better detailed, the sooner we are going to be able to
-fix it. Some questions that can help you guide your issue:
+- bug report, the better detailed, the sooner we are going to be able to fix it. Some questions that can help you guide your issue:
 	- What happend?
 	- What is the expected behavior?
 	- What are the steps to reproduce it?
 	- In which environment the it happend?
 	- Stacktraces, related issues, logs, etc.
 
-- **feature request**, tells us about the motivation of the change, some use
-cases, suggestions on how to implement it, links for context and references
-(**really important**), etc.
-
----
+- feature request, tells us about the motivation of the change, some use cases, suggestions on how to implement it, links for context and references (**really important**), etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,13 @@
-Hi! Thank you for contributing to **Bottery**! Make sure you have followed our
-[Contributing guideline](https://docs.bottery.io/en/latest/contributing.html)
-at the docs. Here is some reminders:
+Hi! Thank you for contributing to **Bottery**! Make sure you have followed our Contributing guideline [1]. Here is some reminders:
 
 - Tests and documentation **are not** optional. Make sure you documented and
 tested the changes you are proposing;
-- Every pull request must be linked to an issue. Explain the problem you're solving
-there, here is how you are fixing it;
-- Briefly describe the changes at the **Bottery Nightly** section on
-*CHANGELOG.md*;
-- The bigger the Pull Request, the harder it is to review it. Break your
-solution into small pieces of code;
+- Every pull request must be linked to an issue. Explain the problem you're solving there, here is how you are fixing it;
+- Briefly describe the changes at the Bottery Nightly section on CHANGELOG.md;
+- The bigger the Pull Request, the harder it is to review it. Break your solution into small pieces of code;
+
+1: https://docs.bottery.io/en/latest/contributing.html
 
 ---
 
-Closes: \<issue-link\>
+Closes: <issue-link>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ _Changes to be released_
 
 - Stop responding with `null` when a view doesn't return anything ([#154](https://github.com/rougeth/bottery/issues/154))
 
+#### Docs
+
+- Simplify Github templates ([#157](https://github.com/rougeth/bottery/issues/157))
+
 
 ## Bottery 0.1.1 (2018-04-28)
 


### PR DESCRIPTION
Make Github Issue and Pull Request templates easier to read with markdown not rendered.

Closes: https://github.com/rougeth/bottery/issues/157
