### PR TITLE
Improve all settings management 

### DIFF
--- a/bottery/conf/__init__.py
+++ b/bottery/conf/__init__.py
@@ -34,16 +34,27 @@ class Settings:
         self._configure_settings_path()
         mod = import_module('settings')
 
+class Settings:
+    def configure(self):
+        self.global_settings()
+        self.import_settings()
+
+    def setattr_module(self, mod):
         for setting in dir(mod):
             if setting.isupper():
                 setattr(self, setting, getattr(mod, setting))
 
+    def local_settings(self):
+        base = os.getcwd()
+        sys.path.insert(0, base)
+        return import_module('settings')
 
-class LazySettings:
-    _wrapped = None
+    def global_settings(self):
+        self.setattr_module(global_settings)
 
-    def _setup(self):
-        self._wrapped = Settings()
+    def import_settings(self):
+        mod = self.local_settings()
+        self.setattr_module(mod)
 
     def __getattr__(self, name):
         if not self._wrapped:

--- a/bottery/conf/__init__.py
+++ b/bottery/conf/__init__.py
@@ -62,4 +62,12 @@ class Settings:
         return getattr(self._wrapped, name)
 
 
+class UserSettingsHolder:
+    def __init__(self, defaut_settings):
+        for key in dir(defaut_settings):
+            if key.isupper():
+                value = getattr(defaut_settings, key)
+                setattr(self, key, deepcopy(value))
+
+
 settings = LazySettings()

--- a/bottery/conf/__init__.py
+++ b/bottery/conf/__init__.py
@@ -6,6 +6,15 @@ from importlib import import_module
 from bottery.conf import global_settings
 
 
+def lazy_obj_method(f):
+    def inner(self, *args):
+        if not self._wrapped:
+            self._setup()
+        return f(self._wrapped, *args)
+
+    return inner
+
+
 class Settings:
     def __init__(self):
         self._global_settings()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,4 +1,3 @@
-import sys
 from unittest import mock
 
 import pytest

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from bottery.conf import UserSettingsHolder, lazy_obj_method
+from bottery.conf import Settings, lazy_obj_method
 
 
 @pytest.mark.parametrize('wrapped,expected_result', (
@@ -18,3 +18,59 @@ def test_lazy_obj_method(wrapped, expected_result):
     dir(settings)
 
     assert settings._setup.called is expected_result
+
+
+def test_settings_configure():
+    settings = Settings()
+    settings.global_settings = mock.Mock()
+    settings.import_settings = mock.Mock()
+
+    settings.configure()
+    assert settings.global_settings.called is True
+    assert settings.import_settings.called is True
+
+
+def test_settings_global_settings():
+    settings = Settings()
+    settings.global_settings()
+
+    assert settings.TEMPLATES == []
+    assert settings.PLATFORMS == {}
+    assert settings.MIDDLEWARES == []
+
+
+@mock.patch('bottery.conf.sys')
+@mock.patch('bottery.conf.import_module')
+@mock.patch('bottery.conf.os.getcwd', return_value='test_settings')
+def test_settings_local_settings(mock_getcwd, mock_import_module, mock_sys):
+    mock_sys.path = []
+
+    settings = Settings()
+    settings.local_settings()
+
+    assert mock_sys.path[0] == 'test_settings'
+    assert mock_import_module.called is True
+    assert mock_getcwd.called is True
+
+
+def test_settings_setattr_module():
+    mod = type('Settings', (), {'VALID': True, 'invalid': False})
+    settings = Settings()
+    settings.setattr_module(mod)
+
+    assert settings.VALID
+    assert not hasattr(settings, 'invalid')
+
+
+@mock.patch('bottery.conf.import_module')
+def test_settings_import_settings(mock_import_module):
+    mod = type('Settings', (), {
+        'DEBUG': True,
+        'anotherconf': True,
+    })
+
+    settings = Settings()
+    settings.local_settings = mock.Mock(return_value=mod)
+    settings.import_settings()
+
+    assert settings.DEBUG

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2,29 +2,19 @@ from unittest import mock
 
 import pytest
 
-from bottery.conf import Settings
+from bottery.conf import UserSettingsHolder, lazy_obj_method
 
 
-@pytest.fixture
-def mocked_settings():
-    settings = mock.MagicMock()
-    sys.modules['settings'] = settings
-    yield settings
-    del sys.modules['settings']
+@pytest.mark.parametrize('wrapped,expected_result', (
+    (False, True), (True, False),
+))
+def test_lazy_obj_method(wrapped, expected_result):
+    class Settings:
+        _wrapped = wrapped
+        _setup = mock.Mock()
+        __dir__ = lazy_obj_method(dir)
 
-
-@pytest.mark.skip
-def test_global_settings():
     settings = Settings()
+    dir(settings)
 
-    assert settings.PLATFORMS == {}
-    assert settings.TEMPLATES == []
-
-
-@pytest.mark.skip
-def test_settings_from_module(mocked_settings):
-    mocked_settings.PLATFORM = 'matrix'
-
-    settings = Settings.from_object('settings')
-    assert settings.PLATFORM == 'matrix'
-    assert settings.PLATFORM == 'matrix'
+    assert settings._setup.called is expected_result

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from bottery.conf import Settings, lazy_obj_method
+from bottery.conf import Settings, UserSettingsHolder, lazy_obj_method
 
 
 @pytest.mark.parametrize('wrapped,expected_result', (
@@ -74,3 +74,16 @@ def test_settings_import_settings(mock_import_module):
     settings.import_settings()
 
     assert settings.DEBUG
+
+
+def test_usersettingsholder():
+    templates = []
+    default_settings = type('Settings', (), {
+        'TEMPLATES': templates,
+        'anotherconf': True,
+    })
+
+    settings = UserSettingsHolder(default_settings)
+    assert settings.TEMPLATES == templates
+    assert id(settings.TEMPLATES) != id(templates)
+    assert not hasattr(settings, 'anotherconf')


### PR DESCRIPTION
My goal with this PR is to make easier to test modules that are depended from `bottery.conf.settings`. With `LazySettings` and `UserSettingsHolder`, it's possible to have settings configured without needing to mock a `settings.py` user module. Now we can do something like:

```python
from bottery.conf import settings
# This doesn't search for a `settings.py` file
settings.configure()
```