### PR TITLE
#175: Changed Bottery.stop behavior.

### DIFF
--- a/bottery/bottery.py
+++ b/bottery/bottery.py
@@ -104,5 +104,5 @@ class Bottery:
         self.loop.run_forever()
 
     def stop(self):
-        self.session.close()
-        self.loop.close()
+        asyncio.gather(self.session.close())
+        self.loop.stop()

--- a/bottery/bottery.py
+++ b/bottery/bottery.py
@@ -101,8 +101,16 @@ class Bottery:
         #     sys.exit(1)
 
         click.echo('Quit the bot with CONTROL-C')
-        self.loop.run_forever()
+
+        try:
+            self.loop.run_forever()
+        except KeyboardInterrupt:
+            self.stop()
+        finally:
+            self.cleanup()
 
     def stop(self):
-        asyncio.gather(self.session.close())
         self.loop.stop()
+
+    def cleanup(self):
+        self.loop.run_until_complete(self.session.close())

--- a/bottery/cli.py
+++ b/bottery/cli.py
@@ -80,8 +80,4 @@ def import_string(import_name):
 @click.option('--port', default=7000, type=int)
 def run(bot_module, port):
     bot = Bottery()
-
-    try:
-        bot.run(server_port=port)
-    except KeyboardInterrupt:
-        bot.stop()
+    bot.run(server_port=port)


### PR DESCRIPTION
This patch fixes two problems in the Bottery.stop behavior:

1. `self.session.close()` was not awaited;
2. `self.loop.close()` causes an exception "Can not close running loop" in some cases.

Closes: #175
